### PR TITLE
Use node:slim as base and use newer Chrome version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,32 @@
-FROM geekykaran/headless-chrome-node-docker:latest
+FROM node:slim
+
+RUN apt-get update -y && \
+    apt-get install ca-certificates \
+      gconf-service \
+      libasound2 \
+      libatk1.0-0 \
+      libatk1.0-0 \
+      libdbus-1-3 \
+      libgconf-2-4 \
+      libgtk-3-0 \
+      libnspr4 \
+      libnss3 \
+      libx11-xcb1 \
+      libxss1 \
+      libxtst6 \
+      fonts-liberation \
+      libappindicator3-1 \
+      xdg-utils \
+      lsb-release \
+      wget \
+      curl \
+      xz-utils -y --no-install-recommends && \
+    wget https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb && \
+    dpkg -i google-chrome*.deb && \
+    apt-get install -f && \
+    apt-get clean autoclean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* google-chrome-unstable_current_amd64.deb
+
 MAINTAINER David J Eddy <me@davidjeddy.com>
 COPY ./ /app
 WORKDIR /app


### PR DESCRIPTION
Thanks for your work @davidjeddy   I plan to use it as a base for an image to use with Gitlab CI.

To that end I thought I'd update it to a more recent base image.
